### PR TITLE
Fix databases with parameters

### DIFF
--- a/copy-data.py
+++ b/copy-data.py
@@ -37,7 +37,8 @@ def copy_data(iris_cpf_file, data_dir):
     # get the [Databases] section
     dbs = config['Databases']
     for db_name, db_path in dbs.items():
-        process_line(db_name, db_path, data_dir)
+        clean_db_path = get_substring_before_first_comma(db_path)
+        process_line(db_name, clean_db_path, data_dir)
 
 def other_copy(data_dir, other_folder):
     # copy the other folders to the data_dir
@@ -58,6 +59,15 @@ def python_copy(data_dir):
 
 def csp_copy(data_dir):
     other_copy(data_dir, 'usr/irissys/csp/')
+
+def get_substring_before_first_comma(s):
+    # Find the index of the first comma
+    index = s.find(',')
+    # If a comma is found, return the substring up to that index
+    if index != -1:
+        return s[:index]
+    # If no comma is found, return the entire string
+    return s
 
 if __name__ == '__main__':
     # parse the command line arguments with argparse


### PR DESCRIPTION
Hi @grongierisc !

Thank you very much for this useful script.
I noticed a small problem with databases that contain parameters, ex:

```
[Databases]
MYAPPCODE=C:\InterSystems\IRISHealth\mgr\MYAPPCODE\,,,,1
```

Parameters can be added after the directory to specify "mount at startup or something like required at startup".
So, we have to clean the value to make the copy.

I added `get_substring_before_first_comma` to fix it.  Feel free to change the implementation (I'm a beginner in Python).

Thank you. 
Regards.

Lorenzo.
